### PR TITLE
allow to choose different scanning patterns of a lidar module

### DIFF
--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -73,7 +73,7 @@ class ignition::sensors::GpuLidarSensorPrivate
   public: transport::Node::Publisher pointPub;
 
   /// \brief Scanning pattern.
-  public: std::string scanningPattern = "avia";
+  public: ignition::rendering::ScanningPattern scanningPattern = ignition::rendering::ScanningPattern::AVIA;
 };
 
 //////////////////////////////////////////////////
@@ -134,10 +134,22 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
 
   if (_sdf.Element()->HasElement("scanning_pattern"))
   {
-    auto pattern = _sdf.Element()->Get<std::string>("scanning_pattern");
-    if (pattern == "rasterizing")
+    auto pattern = _sdf.Element()->Get<std::string>("scanning_pattern");\
+    
+    std::unordered_map<std::string, ignition::rendering::ScanningPattern> patterns {
+      {"avia", ignition::rendering::ScanningPattern::AVIA},
+      {"rasterization", ignition::rendering::ScanningPattern::RASTERIZATION},
+    };
+
+    if (patterns.find(pattern) != patterns.end())
     {
-      this->dataPtr->scanningPattern = pattern;
+      this->dataPtr->scanningPattern = patterns[pattern];
+    }
+    else
+    {
+      ignerr << "Unable to create a lidar with pattern [" 
+             << pattern << "]" << std::endl;
+      return false;
     }
   }
 

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -71,6 +71,9 @@ class ignition::sensors::GpuLidarSensorPrivate
 
   /// \brief Publisher for the publish point cloud message.
   public: transport::Node::Publisher pointPub;
+
+  /// \brief Scanning pattern.
+  public: std::string scanningPattern = "avia";
 };
 
 //////////////////////////////////////////////////
@@ -127,6 +130,15 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
   if (!Lidar::Load(_sdf))
   {
     return false;
+  }
+
+  if (_sdf.Element()->HasElement("scanning_pattern"))
+  {
+    auto pattern = _sdf.Element()->Get<std::string>("scanning_pattern");
+    if (pattern == "rasterizing")
+    {
+      this->dataPtr->scanningPattern = pattern;
+    }
   }
 
   // Initialize the point message.
@@ -233,6 +245,8 @@ bool GpuLidarSensor::CreateLidar()
       std::bind(&GpuLidarSensor::OnNewLidarFrame, this,
       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
       std::placeholders::_4, std::placeholders::_5));
+    
+  this->dataPtr->gpuRays->SetScanningPattern(this->dataPtr->scanningPattern);
 
   this->AddSensor(this->dataPtr->gpuRays);
 

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -136,14 +136,14 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
   {
     auto pattern = _sdf.Element()->Get<std::string>("scanning_pattern");\
     
-    std::unordered_map<std::string, ignition::rendering::ScanningPattern> patterns {
+    const std::unordered_map<std::string, ignition::rendering::ScanningPattern> patterns {
       {"avia", ignition::rendering::ScanningPattern::AVIA},
       {"rasterization", ignition::rendering::ScanningPattern::RASTERIZATION},
     };
 
     if (patterns.find(pattern) != patterns.end())
     {
-      this->dataPtr->scanningPattern = patterns[pattern];
+      this->dataPtr->scanningPattern = patterns.at(pattern);
     }
     else
     {

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -134,7 +134,7 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
 
   if (_sdf.Element()->HasElement("scanning_pattern"))
   {
-    auto pattern = _sdf.Element()->Get<std::string>("scanning_pattern");\
+    auto pattern = _sdf.Element()->Get<std::string>("scanning_pattern");
     
     const std::unordered_map<std::string, ignition::rendering::ScanningPattern> patterns {
       {"avia", ignition::rendering::ScanningPattern::AVIA},


### PR DESCRIPTION
<!---
Pull Request Template
- Please fill the sections below as described in the comments.
- This information simplifies collaboration and helps future readers.
- Reviewers should ask for this info to be filled when missing.
-->

<!---
PR Metadata
- Title: Provide a short summary of the PR changes.
- Assignees: Assign yourself and other direct collaborators.
- Type: Create the PR as a draft. Only set it to non-draft when it is ready to be reviewed.
- Reviewers: Only assign reviewers when the PR is ready to be reviewed.
- Labels: Only assign labels with high priority and important context. Default is label-less.
-->

### Description
<!--- Describe your changes in detail -->
<!--- If there are other links relevant to this PR, mention them here as well -->

Allow the user to choose scanning patterns in `avia` and `rasterizing` in an sdf file.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

To support multiple lidar scanning patterns based on real-world cases.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Readers can use this info to verify or try the changes. -->
<!--- - Code snippet with the commands you used to test this locally. -->
<!--- - Link to relevant CI run. -->
<!--- - Other useful info for reviewers. -->

Shared the result to other engineers.

### Checklist
<!--- Put an `x` in the boxes that apply. -->

- [x] Have you filled the sections above?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same GitHub Issues/ClickUp Task(s)?
- [ ] Have you documented the changes in GitHub Issues and/or ClickUp Task(s) related to this Pull Request?
- [x] Have you added labels, where appropriate, to this Pull Request?

<!--
Do not include screenshots.
- These will be accessible from everyone outside DeepX-inc.
- Add them to the ClickUp task instead.
-->